### PR TITLE
Update Legends Service getLegendByName IgnoreCase

### DIFF
--- a/src/routers/legends/legends.service.ts
+++ b/src/routers/legends/legends.service.ts
@@ -99,6 +99,7 @@ export class LegendsService {
 	}: GetLegendByNameDTO): Promise<
 		APIRes<LegendsEntity & { thumbnail: string }>
 	> {
+		legend_name.toLowerCase();
 		const legendData = await this.legendsRepository.findOne({
 			where: {
 				legend_name_key: legend_name,


### PR DESCRIPTION
When you use the service and you put "oRion, OriOn or orioN" the response is "Not Found", I just added legend name.toLowerCase() in the service to avoid that kind of error :)